### PR TITLE
Fix server shutdown termination send

### DIFF
--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -256,7 +256,11 @@ impl ClientPool {
     }
 
     pub fn shutdown(&self) {
-        self.sender.send(Terminate { client_id: CLIENT_POOL_RESERVED_ID }).unwrap_err();
+        self.sender
+            .send(Terminate {
+                client_id: CLIENT_POOL_RESERVED_ID,
+            })
+            .unwrap();
     }
 }
 


### PR DESCRIPTION
## Summary
- update shutdown logic in server to use unwrap

## Testing
- `cargo build` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683f67e3c04c8325bc34d8cd780c059b