### PR TITLE
Improve README files with project overview and diagram

### DIFF
--- a/mobile_client/README.md
+++ b/mobile_client/README.md
@@ -1,28 +1,20 @@
-# mobile_client
-Get all dependencies:
-```
+# Mobile Client
+
+This Flutter application connects to the Rust server and sends touch events as
+mouse movement data.
+
+## Setup
+```bash
 flutter pub get
-```
-
-
-run the following command to generate the json_serializable classes:
-```
+# generate json_serializable classes
 dart run build_runner build
 ```
-If you get any errors, try running:
-```
+If you encounter errors while generating code, try running:
+```bash
 flutter pub upgrade
 ```
 
-## Getting Started
-
-This project is a starting point for a Flutter application.
-
-A few resources to get you started if this is your first Flutter project:
-
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
-
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+Run the app on a connected device or emulator with:
+```bash
+flutter run
+```

--- a/mobile_client/ios/Runner/Assets.xcassets/LaunchImage.imageset/README.md
+++ b/mobile_client/ios/Runner/Assets.xcassets/LaunchImage.imageset/README.md
@@ -1,5 +1,8 @@
 # Launch Screen Assets
 
-You can customize the launch screen with your own desired assets by replacing the image files in this directory.
+You can customize the launch screen with your own images by replacing the
+files in this directory.
 
-You can also do it by opening your Flutter project's Xcode project with `open ios/Runner.xcworkspace`, selecting `Runner/Assets.xcassets` in the Project Navigator and dropping in the desired images.
+Alternatively, open the Flutter project's Xcode workspace with:
+`open ios/Runner.xcworkspace`, select `Runner/Assets.xcassets`, and drop
+in the desired images.

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,63 @@
+# Mobile Virtual Device
 
-Install X11
+This project enables using a mobile phone as a remote pointing device for a desktop machine.
+It is composed of:
 
-```sudo apt-get install libxtst-dev```
+- **server** – a Rust application that listens for incoming connections and forwards
+  the received bytes to a virtual input device.
+- **client** – a simple Rust command line program used for experiments.
+- **mobile_client** – a Flutter application that provides a mobile UI.
 
-Compile
+Each client initially connects to the server on port `7878`. The server then assigns
+an individual port and spawns a thread to handle that connection. Input bytes sent by
+the client are dispatched to the device application running on the server.
 
-```gcc virtual-mouse2.c -o virtual-mouse2 -lX11 -lXtst```
+## Build and run
+
+### Server
+```bash
+sudo apt install build-essential libxdo-dev
+cd server
+cargo run
+```
+
+Run with logging:
+```bash
+RUST_LOG=info cargo run
+```
+
+### Mobile client
+```bash
+cd mobile_client
+flutter pub get
+# generate json_serializable classes
+dart run build_runner build
+flutter run
+```
+
+## Virtual mouse helper
+The root of the repository contains a small C helper used to build a virtual mouse
+for testing purposes.
+
+Install dependencies and compile it with:
+```bash
+sudo apt-get install libxtst-dev
+gcc virtual-mouse2.c -o virtual-mouse2 -lX11 -lXtst
+```
+
+## Architecture
+```mermaid
+sequenceDiagram
+    participant Mobile
+    participant AcceptThread as "Server: Accept thread"
+    participant ClientThread as "Server: Client thread"
+    participant App as "Device application"
+
+    Mobile->>AcceptThread: Connect to 7878
+    AcceptThread-->>Mobile: Send new port & OS
+    Mobile->>ClientThread: Connect to assigned port
+    ClientThread->>App: Forward input bytes
+    Mobile-->>ClientThread: Disconnect command
+    ClientThread->>AcceptThread: Notify termination
+```
 

--- a/server/readme.md
+++ b/server/readme.md
@@ -1,20 +1,23 @@
-# Depedencies
+# Server
 
-On Linux it must be runned with X11 windowing system.
-If you are on Wayland, you can log out and change to Ubuntu Xorg to use X11
+## Dependencies
+The server targets Linux and requires the X11 windowing system. On Wayland based
+desktops, log out and choose an Xorg session.
+Install the build tools and `libxdo`:
 
-# How to run
-
-```
+```bash
 sudo apt install build-essential libxdo-dev
 ```
 
-```
+## Running
+Use `cargo run` while inside the `server` directory:
+```bash
 cargo run
 ```
 
-Run with loggers (level info & lower):
-```
+Enable logging:
+```bash
 RUST_LOG=info cargo run
 ```
 
+For release builds use `cargo build --release`.


### PR DESCRIPTION
## Summary
- document project setup and flow in the main README
- refine server usage notes
- clarify mobile client steps
- clean up iOS asset README

## Testing
- `cargo test --manifest-path server/Cargo.toml` *(fails: could not compile `server`)*

------
https://chatgpt.com/codex/tasks/task_e_6844ca294e2c832586c41249c22c5b34